### PR TITLE
feat: Add threaded serial init and response console to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,55 @@
-# Initial Communication Module
+# Microstep Control
 
-**This project is currently in draft/early development stage.**
+**Status:** Draft · Early Development
 
-This Python module is part of an early-stage project aiming to develop a **microscope camera system integrated with CNC control**.  
-The goal is to enable synchronized image capture and precise CNC hardware manipulation for advanced prototyping, analysis, and automation tasks.
+**Microstep Control** is an experimental Python-based microscope camera and CNC control interface. It combines image streaming, serial CNC communication, and precise positioning into a unified GUI application. The goal is to build a flexible foundation for advanced analysis, prototyping, and automation workflows.
 
-Currently, the stable version does not utilize WMI for camera detection (Windows only), but this is planned.  
-Future development will add support for both Windows and Linux platforms and include a graphical user interface (GUI).  
-Further enhancements will include image analysis and AI-assisted functionalities to enhance system capabilities.
+---
 
-## Features
+## 🔧 Project Goals
 
-- Detects available serial ports and identifies CNC devices by sending configurable commands.
-- Lists connected cameras with friendly names using FFmpeg and Windows WMI (planned).
-- Provides a user-friendly console interface to select CNC serial port and camera.
-- Supports integration with OpenCV for camera streaming.
-- Planned: cross-platform support (Windows and Linux).
-- Planned: GUI for easier device selection and control.
+- Integrate a microscope camera with a CNC motion system
+- Provide a real-time image preview using OpenCV
+- Enable axis movement via GUI buttons (X/Y/Z with step size)
+- Display CNC responses live without interruptive dialogs
+- Prepare for AI-based image processing and control
+- Cross-platform compatibility (Windows now, Linux planned)
+- Future-proof modular design with serial abstraction and pluggable components
 
-## Requirements
+---
 
-- Python 3.7+
+## 🖼️ Features (Current Stage)
+
+- Detect connected serial ports and identify CNC boards
+- Discover video capture devices using FFmpeg (Windows only for now)
+- Connect and stream from selected camera using OpenCV
+- Send CNC commands over serial (e.g., G28, G1, G91/G90)
+- Live response feedback via console-style text box
+- Step-based control for X/Y/Z axis via GUI buttons
+- Adjustable step size in mm
+- Modular backend design: `initial_communication_base.py`, `cnc_control.py`, `stream.py`
+
+---
+
+## 📦 Requirements
+
+- Python 3.8+
+- `PySide6`
 - `pyserial`
 - `opencv-python`
-- `wmi` (Windows only, planned)
-- FFmpeg binary accessible (configured via path in code)
+- `ffmpeg` (binary must be present and configured in code path)
 
-## Installation
+**Optional (planned):**
 
-1. Clone the repository or copy the files.
-2. Install dependencies:
+- `wmi` (Windows-only, camera info via WMI)
+- `numpy`, `pillow`, `tensorflow` (for AI and image analysis, future)
+
+---
+
+## 📥 Installation
+
+1. Clone this repository:
 
 ```bash
-pip install -r requirements.txt
+git clone https://github.com/yourusername/microstep_v.0.001.git
+cd microstep_v.0.001

--- a/cnc_control.py
+++ b/cnc_control.py
@@ -2,11 +2,12 @@ import serial
 import time
 
 class CNCController:
-    def __init__(self, port, baudrate=115200, timeout=1):
+    def __init__(self, port, baudrate=115200, timeout=3):
         self.port = port
         self.baudrate = baudrate
         self.timeout = timeout
         self.ser = None
+        self.step_size = 1.0  # Default step size in mm
 
     def connect(self):
         """Establish serial connection to the CNC device."""
@@ -36,3 +37,33 @@ class CNCController:
         if self.ser and self.ser.is_open:
             self.ser.close()
             print("CNC connection closed.")
+
+    def set_step_size(self, step):
+        """Set the step size in millimeters for axis movements."""
+        if step > 0:
+            self.step_size = float(step)
+            print(f"Step size set to {self.step_size} mm")
+        else:
+            print("Step size must be a positive number.")
+
+    def home(self, cmd ="G28\n"):
+        """Move home"""
+        return self.send_command(cmd)
+
+    def move_x(self, direction=1):
+        """Move the X axis by step_size in the specified direction (+1 or -1)."""
+        distance = direction * self.step_size
+        cmd = f"G91\nG0 X{distance}\nG90"
+        return self.send_command(cmd)
+
+    def move_y(self, direction=1):
+        """Move the Y axis by step_size in the specified direction (+1 or -1)."""
+        distance = direction * self.step_size
+        cmd = f"G91\nG0 Y{distance}\nG90"
+        return self.send_command(cmd)
+
+    def move_z(self, direction=1):
+        """Move the Z axis by step_size in the specified direction (+1 or -1)."""
+        distance = direction * self.step_size
+        cmd = f"G91\nG0 Z{distance}\nG90"
+        return self.send_command(cmd)

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,246 @@
+from PySide6.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QPushButton, QLabel, QHBoxLayout,
+    QMessageBox, QComboBox, QGroupBox, QFormLayout, QLineEdit, QTextEdit
+)
+from PySide6.QtCore import QTimer, QThread, Signal
+from PySide6.QtGui import QImage, QPixmap
+
+import sys
+import cv2
+import time
+
+from initialial_communication_base import InitialCommunication
+from stream import CameraStream
+from cnc_control import CNCController
+
+
+class InitReaderThread(QThread):
+    new_line = Signal(str)
+
+    def __init__(self, ser):
+        super().__init__()
+        self.ser = ser
+        self.running = True
+
+    def run(self):
+        while self.running and self.ser and self.ser.is_open:
+            if self.ser.in_waiting:
+                line = self.ser.readline().decode('utf-8', errors='ignore').strip()
+                if line:
+                    self.new_line.emit(line)
+            else:
+                self.msleep(50)
+
+    def stop(self):
+        self.running = False
+        self.wait()
+
+
+class MicroscopeGUI(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Microstep Control")
+        self.setGeometry(100, 100, 800, 750)
+
+        self.comm = InitialCommunication(debug=False)
+        self.cnc_controller = None
+        self.cap = None
+        self.reader_thread = None
+
+        self.available_cams = []
+        self.available_ports = []
+
+        self.init_ui()
+
+        self.timer = QTimer()
+        self.timer.timeout.connect(self.update_frame)
+
+        self.populate_device_lists()
+
+    def init_ui(self):
+        layout = QVBoxLayout()
+
+        device_group = QGroupBox("Device Selection")
+        device_form = QFormLayout()
+
+        self.cam_dropdown = QComboBox()
+        self.port_dropdown = QComboBox()
+
+        device_form.addRow("Camera:", self.cam_dropdown)
+        device_form.addRow("CNC Port:", self.port_dropdown)
+
+        device_group.setLayout(device_form)
+        layout.addWidget(device_group)
+
+        self.video_label = QLabel("Camera preview will appear here")
+        self.video_label.setFixedHeight(480)
+        layout.addWidget(self.video_label)
+
+        self.response_box = QTextEdit()
+        self.response_box.setReadOnly(True)
+        self.response_box.setFixedHeight(80)
+        layout.addWidget(self.response_box)
+
+        button_layout = QHBoxLayout()
+        self.connect_button = QPushButton("Connect Devices")
+        self.connect_button.clicked.connect(self.handle_device_selection)
+
+        self.cnc_button = QPushButton("Send G28")
+        self.cnc_button.clicked.connect(self.send_cnc_command)
+        self.cnc_button.setEnabled(False)
+
+        self.stop_button = QPushButton("Stop Camera")
+        self.stop_button.clicked.connect(self.stop_camera)
+        self.stop_button.setEnabled(False)
+
+        button_layout.addWidget(self.connect_button)
+        button_layout.addWidget(self.cnc_button)
+        button_layout.addWidget(self.stop_button)
+
+        layout.addLayout(button_layout)
+
+        cnc_move_group = QGroupBox("CNC Movement Controls")
+        cnc_move_layout = QVBoxLayout()
+
+        step_layout = QHBoxLayout()
+        step_label = QLabel("Step size (mm):")
+        self.step_input = QLineEdit("1.0")
+        step_layout.addWidget(step_label)
+        step_layout.addWidget(self.step_input)
+        cnc_move_layout.addLayout(step_layout)
+
+        xyz_button_layout = QHBoxLayout()
+
+        x_layout = QVBoxLayout()
+        self.btn_x_pos = QPushButton("X+")
+        self.btn_x_neg = QPushButton("X-")
+        x_layout.addWidget(self.btn_x_pos)
+        x_layout.addWidget(self.btn_x_neg)
+        xyz_button_layout.addLayout(x_layout)
+
+        y_layout = QVBoxLayout()
+        self.btn_y_pos = QPushButton("Y+")
+        self.btn_y_neg = QPushButton("Y-")
+        y_layout.addWidget(self.btn_y_pos)
+        y_layout.addWidget(self.btn_y_neg)
+        xyz_button_layout.addLayout(y_layout)
+
+        z_layout = QVBoxLayout()
+        self.btn_z_pos = QPushButton("Z+")
+        self.btn_z_neg = QPushButton("Z-")
+        z_layout.addWidget(self.btn_z_pos)
+        z_layout.addWidget(self.btn_z_neg)
+        xyz_button_layout.addLayout(z_layout)
+
+        cnc_move_layout.addLayout(xyz_button_layout)
+        cnc_move_group.setLayout(cnc_move_layout)
+        layout.addWidget(cnc_move_group)
+
+        self.btn_x_pos.clicked.connect(lambda: self.move_axis('X', 1))
+        self.btn_x_neg.clicked.connect(lambda: self.move_axis('X', -1))
+        self.btn_y_pos.clicked.connect(lambda: self.move_axis('Y', 1))
+        self.btn_y_neg.clicked.connect(lambda: self.move_axis('Y', -1))
+        self.btn_z_pos.clicked.connect(lambda: self.move_axis('Z', 1))
+        self.btn_z_neg.clicked.connect(lambda: self.move_axis('Z', -1))
+
+        self.setLayout(layout)
+
+    def populate_device_lists(self):
+        serial_ports_info = self.comm.get_serial_port_info()
+        self.available_ports = [info[0] for info in serial_ports_info]
+        self.port_dropdown.clear()
+        for port, desc, vidpid in serial_ports_info:
+            self.port_dropdown.addItem(f"{port} - {desc} (VID:PID={vidpid})")
+
+        cam_infos = self.comm.find_cameras()
+        self.available_cams = [i for i, _ in cam_infos]
+        self.cam_dropdown.clear()
+        for i, name in cam_infos:
+            self.cam_dropdown.addItem(f"{i}: {name}")
+
+    def handle_device_selection(self):
+        self.stop_camera()
+        if self.cnc_controller:
+            self.cnc_controller.disconnect()
+            self.cnc_controller = None
+        self.cnc_button.setEnabled(False)
+
+        cam_index = self.cam_dropdown.currentIndex()
+        if cam_index >= 0 and cam_index < len(self.available_cams):
+            self.cap = cv2.VideoCapture(self.available_cams[cam_index])
+            if not self.cap.isOpened():
+                self.response_box.append("Could not open selected camera.")
+                return
+            self.timer.start(30)
+            self.stop_button.setEnabled(True)
+        else:
+            self.cap = None
+
+        port_index = self.port_dropdown.currentIndex()
+        if port_index >= 0 and port_index < len(self.available_ports):
+            port = self.available_ports[port_index]
+            self.cnc_controller = CNCController(port)
+            self.cnc_controller.connect()
+            if self.cnc_controller.ser and self.cnc_controller.ser.is_open:
+                self.reader_thread = InitReaderThread(self.cnc_controller.ser)
+                self.reader_thread.new_line.connect(self.response_box.append)
+                self.reader_thread.start()
+                self.response_box.append(f"CNC connected on {port}. Awaiting initialization response from device...")
+                self.cnc_button.setEnabled(True)
+            else:
+                self.response_box.append(f"Port {port} could not be opened.")
+                self.cnc_controller = None
+        else:
+            self.cnc_controller = None
+
+    def move_axis(self, axis, direction):
+        if not self.cnc_controller:
+            self.response_box.append("No CNC controller connected.")
+            return
+
+        try:
+            step_size = float(self.step_input.text())
+        except ValueError:
+            self.response_box.append("Step size must be a valid number.")
+            return
+
+        distance = step_size * direction
+        self.cnc_controller.send_command("G91")
+        cmd = f"G1 {axis}{distance:.3f} F3000"
+        response = self.cnc_controller.send_command(cmd)
+        self.cnc_controller.send_command("G90")
+        self.response_box.append(f"Move {axis}  {distance}mm   Status: {response or 'No response.'}")
+
+    def update_frame(self):
+        if self.cap is not None and self.cap.isOpened():
+            ret, frame = self.cap.read()
+            if ret:
+                rgb_image = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                h, w, ch = rgb_image.shape
+                bytes_per_line = ch * w
+                qt_image = QImage(rgb_image.data, w, h, bytes_per_line, QImage.Format_RGB888)
+                pixmap = QPixmap.fromImage(qt_image)
+                self.video_label.setPixmap(pixmap)
+
+    def stop_camera(self):
+        if self.cap:
+            self.cap.release()
+            self.cap = None
+        self.timer.stop()
+        self.video_label.clear()
+        self.stop_button.setEnabled(False)
+
+    def send_cnc_command(self):
+        if self.cnc_controller:
+            response = self.cnc_controller.send_command("G28")
+            self.response_box.append(f"CNC Response: {response or 'No response.'}")
+        else:
+            self.response_box.append("No CNC controller connected.")
+
+    def closeEvent(self, event):
+        self.stop_camera()
+        if self.reader_thread:
+            self.reader_thread.stop()
+        if self.cnc_controller:
+            self.cnc_controller.disconnect()
+        event.accept()

--- a/main.py
+++ b/main.py
@@ -1,26 +1,12 @@
-from initialial_communication_base import InitialCommunication
-from cnc_control import CNCController
-from stream import CameraStream
+import sys
+from PySide6.QtWidgets import QApplication
+from gui import MicroscopeGUI
 
 def main():
-    initializer = InitialCommunication()
-    cnc_port, cam_index = initializer.select_devices()
-
-    if cnc_port:
-        print(f"Selected CNC: {cnc_port}")
-        cnc = CNCController(port=cnc_port)
-        cnc.connect()
-        cnc.send_command('G28')
-        cnc.disconnect()
-    else:
-        print("No CNC selected.")
-
-    if cam_index is not None:
-        print(f"Selected camera: {cam_index}")
-        cam_stream = CameraStream(cam_index=cam_index)
-        cam_stream.start_stream()
-    else:
-        print("No camera selected.")
+    app = QApplication(sys.argv)
+    window = MicroscopeGUI()
+    window.show()
+    sys.exit(app.exec())
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyserial
 opencv-python
+pyside6
 wmi; platform_system=="Windows"


### PR DESCRIPTION
- Implemented InitReaderThread for reading CNC status asynchronously.
- Added QTextEdit widget to display CNC responses instead of popups.
- Enhanced CNC movement controls (G91/G90 wrapped).
- Reworked device connection logic to display serial feedback on connect.
- Cleaned up camera and CNC connection handling.

This prepares the interface for future status monitoring and improves usability.